### PR TITLE
fix: added cuda check for loading the model

### DIFF
--- a/reinvent_models/lib_invent/models/model.py
+++ b/reinvent_models/lib_invent/models/model.py
@@ -51,7 +51,10 @@ class DecoratorModel:
         :param mode: Mode in which the model should be initialized.
         :return: An instance of the RNN.
         """
-        data = torch.load(path)
+        if torch.cuda.is_available():
+            data = torch.load(path)
+        else:
+            data = torch.load(path, map_location=torch.device('cpu'))
 
         decorator = Decorator(**data["decorator"]["params"])
         decorator.load_state_dict(data["decorator"]["state"])


### PR DESCRIPTION
This PR contains a fix for loading the model when the device is not cuda enabled, I have added a check for cuda while loading the model and setting the map_location to cpu when the device is not cuda enabled. 

@drugilsberg Please review it and let me know if any changes are required. thanks!! 